### PR TITLE
Allow prepending transformations to conclusions

### DIFF
--- a/src/rapanui.core/src/rapanui/core/Application.java
+++ b/src/rapanui.core/src/rapanui/core/Application.java
@@ -31,8 +31,9 @@ public class Application {
 			notifyObservers(o -> o.environmentRemoved(environment));
 	}
 
-	public Emitter<Transformation> loadSuggestions(ConclusionProcess target, BINARY_RELATION suggestionType) {
-		return SuggestionFinder.getDefaultInstance().makeSuggestionsAsync(target, suggestionType);
+	public Emitter<Transformation> loadSuggestions(ConclusionProcess target, BINARY_RELATION suggestionType,
+			boolean prependSuggestion) {
+		return SuggestionFinder.getDefaultInstance().makeSuggestionsAsync(target, suggestionType, prependSuggestion);
 	}
 
 	public void applySuggestion(ConclusionProcess target, Transformation suggestion) {

--- a/src/rapanui.core/src/rapanui/core/ConclusionProcess.java
+++ b/src/rapanui.core/src/rapanui/core/ConclusionProcess.java
@@ -16,7 +16,7 @@ import static rapanui.core.Patterns.*;
  */
 public class ConclusionProcess {
 	private final ProofEnvironment environment;
-	private final Term startTerm;
+	private final Term initialTerm;
 	private final List<Transformation> transformations = new LinkedList<Transformation>();
 	private final List<Observer> observers = new LinkedList<Observer>();
 
@@ -24,14 +24,14 @@ public class ConclusionProcess {
 	 * Creates a new conclusion process
 	 *
 	 * @param environment The environment containing the process. Must not be null.
-	 * @param startTerm The initial term of the process. Must not be null.
+	 * @param initialTerm The initial term of the process. Must not be null.
 	 */
-	ConclusionProcess(ProofEnvironment environment, Term startTerm) {
+	ConclusionProcess(ProofEnvironment environment, Term initialTerm) {
 		assert environment != null;
-		assert startTerm != null;
+		assert initialTerm != null;
 
 		this.environment = environment;
-		this.startTerm = startTerm;
+		this.initialTerm = initialTerm;
 	}
 
 	/**
@@ -42,10 +42,13 @@ public class ConclusionProcess {
 	}
 
 	/**
-	 * @return The conclusion's start term. Guaranteed to be non-null.
+	 * Retrieves the (current) first term in the transformation chain.
+	 * @return The input term of the first transformation, or if there are none, the initial term. Guaranteed to be non-null.
 	 */
-	public Term getStartTerm() {
-		return startTerm;
+	public Term getFirstTerm() {
+		if (transformations.isEmpty())
+			return initialTerm;
+		return transformations.get(0).getInput();
 	}
 
 	/**
@@ -53,8 +56,8 @@ public class ConclusionProcess {
 	 * @return The output term of the last transformation, or if there are none, the initial term. Guaranteed to be non-null.
 	 */
 	public Term getLastTerm() {
-		if (transformations.size() == 0)
-			return startTerm;
+		if (transformations.isEmpty())
+			return initialTerm;
 		return transformations.get(transformations.size() - 1).getOutput();
 	}
 
@@ -66,7 +69,7 @@ public class ConclusionProcess {
 		Transformation[] transformations = getTransformations();
 		Term[] terms = new Term[1+transformations.length];
 
-		terms[0] = getStartTerm();
+		terms[0] = getFirstTerm();
 		for (int i = 0; i < transformations.length; ++i)
 			terms[i+1] = transformations[i].getOutput();
 

--- a/src/rapanui.core/src/rapanui/core/SuggestionFinder.java
+++ b/src/rapanui.core/src/rapanui/core/SuggestionFinder.java
@@ -35,8 +35,13 @@ public class SuggestionFinder {
 		return defaultInstance;
 	}
 
-	public Emitter<Transformation> makeSuggestionsAsync(ConclusionProcess target, BINARY_RELATION suggestionType) {
-		Formula formulaTemplate = Builder.createFormula(target.getLastTerm(), suggestionType, null);
+	public Emitter<Transformation> makeSuggestionsAsync(ConclusionProcess target, BINARY_RELATION suggestionType,
+			boolean prependSuggestion) {
+		Formula formulaTemplate;
+		if (prependSuggestion)
+			formulaTemplate = Builder.createFormula(null, suggestionType, target.getFirstTerm());
+		else
+			formulaTemplate = Builder.createFormula(target.getLastTerm(), suggestionType, null);
 		return justificationFinder.justifyAsync(target.getEnvironment(), formulaTemplate, MAX_RECURSION)
 			.map(justification -> createTransformation(target, justification));
 	}

--- a/src/rapanui.core/test/rapanui/core/test/ProofSteps.java
+++ b/src/rapanui.core/test/rapanui/core/test/ProofSteps.java
@@ -56,7 +56,7 @@ public class ProofSteps {
 			suggestionType = BINARY_RELATION.INCLUSION;
 
 		List<Transformation> suggestions = Collections.synchronizedList(new LinkedList<Transformation>());
-		SuggestionFinder.getDefaultInstance().makeSuggestionsAsync(currentConclusion, suggestionType)
+		SuggestionFinder.getDefaultInstance().makeSuggestionsAsync(currentConclusion, suggestionType, false)
 			.onEmit(suggestions::add);
 
 		try {

--- a/src/rapanui.ui/src/rapanui/ui/ProofFormatter.java
+++ b/src/rapanui.ui/src/rapanui/ui/ProofFormatter.java
@@ -129,9 +129,9 @@ public class ProofFormatter {
 		}
 
 		text("Somit gilt:\n");
-		math(conclusion.getStartTerm().serialize());
+		math(conclusion.getFirstTerm().serialize());
 
-		int padLength = conclusion.getStartTerm().serialize().length();
+		int padLength = conclusion.getFirstTerm().serialize().length();
 		String pad = CharBuffer.allocate( padLength ).toString().replace('\0', ' ');
 
 		Term[] terms = conclusion.getTerms();

--- a/src/rapanui.ui/src/rapanui/ui/models/ApplicationModel.java
+++ b/src/rapanui.ui/src/rapanui/ui/models/ApplicationModel.java
@@ -95,10 +95,10 @@ public class ApplicationModel implements Application.Observer {
 		app.removeEnvironment(environmentModel.getUnderlyingModel());
 	}
 
-	void loadSuggestions(ProofEnvironment environment, ConclusionProcess conclusion) {
+	void loadSuggestions(ProofEnvironment environment, ConclusionProcess conclusion, boolean prependSuggestion) {
 		clearSuggestions();
 
-		activeSuggestionSource = app.loadSuggestions(conclusion, BINARY_RELATION.UNSPECIFIED); // TODO: make suggestionType configurable via UI
+		activeSuggestionSource = app.loadSuggestions(conclusion, BINARY_RELATION.UNSPECIFIED, prependSuggestion); // TODO: make suggestionType configurable via UI
 		activeSuggestionSource.onEmit(this::displaySuggestion);
 	}
 

--- a/src/rapanui.ui/src/rapanui/ui/models/ConclusionProcessModel.java
+++ b/src/rapanui.ui/src/rapanui/ui/models/ConclusionProcessModel.java
@@ -20,6 +20,8 @@ public class ConclusionProcessModel implements ConclusionProcess.Observer {
 
 	private final List<Observer> observers = new LinkedList<Observer>();
 
+	private boolean prependSuggestion = false;
+
 	ConclusionProcessModel(ProofEnvironmentModel container, ConclusionProcess conclusion) {
 		this.container = container;
 		this.conclusion = conclusion;
@@ -68,11 +70,17 @@ public class ConclusionProcessModel implements ConclusionProcess.Observer {
 	}
 
 	void loadSuggestions() {
-		container.loadSuggestions(conclusion);
+		container.loadSuggestions(conclusion, prependSuggestion);
 	}
 
 	void clearSuggestions() {
 		container.clearSuggestions();
+	}
+
+	public void toggleTransformationDirection() {
+		prependSuggestion = !prependSuggestion;
+		if (isActive())
+			loadSuggestions(); // reload
 	}
 
 	public void displayJustification(Justification justification) {

--- a/src/rapanui.ui/src/rapanui/ui/models/ConclusionProcessModel.java
+++ b/src/rapanui.ui/src/rapanui/ui/models/ConclusionProcessModel.java
@@ -34,7 +34,7 @@ public class ConclusionProcessModel implements ConclusionProcess.Observer {
 
 	public String getTitle() {
 		return String.format("%s %s %s",
-				conclusion.getStartTerm().serialize(),
+				conclusion.getFirstTerm().serialize(),
 				conclusion.getFormulaType().getLiteral(),
 				conclusion.getLastTerm().serialize());
 	}
@@ -43,8 +43,8 @@ public class ConclusionProcessModel implements ConclusionProcess.Observer {
 		return conclusion.getTransformations();
 	}
 
-	public Term getStartTerm() {
-		return conclusion.getStartTerm();
+	public Term getFirstTerm() {
+		return conclusion.getFirstTerm();
 	}
 
 	public void activate() {

--- a/src/rapanui.ui/src/rapanui/ui/models/ProofEnvironmentModel.java
+++ b/src/rapanui.ui/src/rapanui/ui/models/ProofEnvironmentModel.java
@@ -98,9 +98,9 @@ public class ProofEnvironmentModel implements ProofEnvironment.Observer {
 		return activeConclusion;
 	}
 
-	void loadSuggestions(ConclusionProcess conclusion) {
+	void loadSuggestions(ConclusionProcess conclusion, boolean prependSuggestion) {
 		if (isActive())
-			container.loadSuggestions(env, conclusion);
+			container.loadSuggestions(env, conclusion, prependSuggestion);
 	}
 
 	void clearSuggestions() {

--- a/src/rapanui.ui/src/rapanui/ui/views/ConclusionProcessView.java
+++ b/src/rapanui.ui/src/rapanui/ui/views/ConclusionProcessView.java
@@ -69,7 +69,7 @@ class ConclusionProcessView extends JPanel implements ConclusionProcessModel.Obs
 		c.ipadx = 5;
 		c.anchor = GridBagConstraints.EAST;
 		c.weightx = 0.3;
-		longForm.add(ProofEnvironmentView.createMathematicalLabel(model.getStartTerm().serialize()), c);
+		longForm.add(ProofEnvironmentView.createMathematicalLabel(model.getFirstTerm().serialize()), c);
 
 		add(header);
 		add(separator);


### PR DESCRIPTION
Allow the user to start a conclusion with the bigger set and find subsets. This is useful because the current algorithm can't use many rules when given only the left term. For example:

```
axiom "smallest set"
  always ∅ ⊆ M
```

**_Given the left side**_, an infinite number of terms (literally any term) may take the role of `M` in this rule. However, the software can't make an infinite number of suggestions and therefore makes none. **_Given the right side**_, a suggestion could easily be made.

This mainly concerns conclusions. Formulas need not be modified, as this would only complicate matters.
